### PR TITLE
Modernize & add timestamps to logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM quay.io/democracyworks/clojure-api-supervisor:latest
+FROM clojure:lein-2.6.1-alpine
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
-ONBUILD ADD ./resources/ /var/local/s3-ftp/resources/
+RUN mkdir /ftpdata
 
-ADD ./target/s3-ftp.jar /var/local/s3-ftp/
-ADD docker/start-s3-ftp.sh /start-s3-ftp.sh
-ADD docker/supervisord-s3-ftp.conf /etc/supervisor/conf.d/supervisord-s3-ftp.conf
+RUN mkdir -p /usr/src/s3-ftp
+WORKDIR /usr/src/s3-ftp
+
+ADD ./project.clj /usr/src/s3-ftp/project.clj
+
+RUN lein deps
+
+ADD . /usr/src/s3-ftp/
+
+RUN lein uberjar
+
+EXPOSE 21 57649 57650 57651 57652 57653 57654 57655 57656 57657 57658 57659
+
+CMD ["java", "-cp", "/usr/src/s3-ftp/resources:/usr/src/s3-ftp/target/s3-ftp.jar", "s3_ftp.core"]

--- a/README.md
+++ b/README.md
@@ -30,23 +30,21 @@ the API documentation for [com.amazonaws.regions.Regions](http://docs.aws.amazon
 
 ## Usage
 
-It can be run locally by just using 
+It can be run locally by just using
 
 `lein run`
 
-To run it inside a docker container, first build the uberjar by running
+To run it inside a docker container, run:
 
 `script/build`
 
-Then build your base docker image by running 
-
-`docker build -t democracyworks/s3-ftp .`
-
-This image contains no configuration and cannot be run. You need to build another image that uses `s3-ftp` as it's base image, creates the homedirectory you specified in your `users.properties`, exposes your active and passive ports and has in its build context a `resources` directory containing your `config.edn` and `user.properties` files.
-
-`docker build -t democracyworks/my-s3-ftp path/to/other/dockerfile`
-
 Finally, run the docker image making sure to expose your configured active and passive ports.
+Like this:
+
+`docker run -d -p 21:21 -p 57649:57649 -p 57650:57650 -p 57651:57651 \
+            -p 57652:57652 -p 57653:57653 -p 57654:57654 -p 57655:57655 \
+            -p 57656:57656 -p 57657:57657 -p 57658:57658 -p 57659:57659 \
+            quay.io/democracyworks/s3-ftp`
 
 ## TLS
 

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -27,7 +27,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
     <encoder>
-      <pattern>%-5level %logger{36} - [%X{remoteAddress}] %msg%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} %-5level [%logger] \(%thread\) %message%n</pattern>
     </encoder>
     <!-- Only log level INFO and above -->
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/project.clj
+++ b/project.clj
@@ -3,18 +3,18 @@
   :url "http://github.com/turbovote/s3-ftp"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clojure-tools "1.1.2"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clojure-tools "1.1.3"]
                  [org.apache.ftpserver/ftpserver-core "1.0.6" :exclusions [org.slf4j/slf4j-api]]
                  [org.apache.ftpserver/ftplet-api "1.0.6"]
-                 [ch.qos.logback/logback-classic "1.0.13"]
-                 [clj-aws-s3 "0.3.8"]
-                 [com.cemerick/bandalore "0.0.5"]
+                 [ch.qos.logback/logback-classic "1.1.7"]
+                 [clj-aws-s3 "0.3.10"]
+                 [com.cemerick/bandalore "0.0.6"]
                  [turbovote.resource-config "0.1.1"]]
   :resource-paths ["config", "resources"]
   :main s3-ftp.core
   :profiles {:build [:uberjar]
              :uberjar {:aot [s3-ftp.core]}
-             :test {:dependencies [[com.velisco/clj-ftp "0.3.0"]]
+             :test {:dependencies [[com.velisco/clj-ftp "0.3.6"]]
                     :resource-paths ["test-resources"]}}
   :uberjar-name "s3-ftp.jar")

--- a/project.clj
+++ b/project.clj
@@ -13,8 +13,7 @@
                  [turbovote.resource-config "0.1.1"]]
   :resource-paths ["config", "resources"]
   :main s3-ftp.core
-  :profiles {:build [:uberjar]
-             :uberjar {:aot [s3-ftp.core]}
+  :profiles {:uberjar {:aot [s3-ftp.core]}
              :test {:dependencies [[com.velisco/clj-ftp "0.3.6"]]
                     :resource-paths ["test-resources"]}}
   :uberjar-name "s3-ftp.jar")

--- a/script/build
+++ b/script/build
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-# Exit if any command fails
 set -e
 
-echo "Building Docker image for s3-ftp build..."
-docker build -t democracyworks/s3-ftp-build - < Dockerfile.build
-echo "Done."
-
-echo "Building s3-ftp..."
-
-docker run -v "$(pwd)":/s3-ftp democracyworks/s3-ftp-build
-
-echo "Done."
+docker build -t quay.io/democracyworks/s3-ftp .


### PR DESCRIPTION
This has some of the modernization work we need to do in these old services (and is already running in production as a triage mechanism when I couldn't even see what this thing was logging before).

It also has the work called for in [this pivotal card](https://www.pivotaltracker.com/story/show/122049365) to add timestamps to the console log messages, which are the logs you see when you run `docker logs -f ...` on the container.

Seemed like we might as well get all this merged to master since it's running in prod anyway.

I essentially just made the console log format look like our other services. When I did a local `lein run` with these logback.xml changes, I got this on the console:
`13:22:06.966 INFO  [org.apache.ftpserver.impl.DefaultFtpServer] (main) FTP server started`